### PR TITLE
[FIX] YAML to YML

### DIFF
--- a/bin/autoaggregate
+++ b/bin/autoaggregate
@@ -1,6 +1,14 @@
 #!/bin/bash
 set -e
-conf=/opt/odoo/custom/src/repos.yaml
+
+conf=/opt/odoo/custom/src/repos
+
+if [ -f "${conf}.yaml" ]; then
+    conf="${conf}.yaml"
+elif [ -f "${conf}.yml" ]; then
+    conf="${conf}.yml"
+fi
+
 # Update linked repositories, if the `repos.yaml` file is found
 if [ -f $conf ]; then
     log INFO Aggregating repositories from $conf

--- a/lib/odoobaselib.py
+++ b/lib/odoobaselib.py
@@ -6,11 +6,16 @@ import yaml
 
 # Constants needed in scripts
 SRC_DIR = "/opt/odoo/custom/src"
-ADDONS_YAML = SRC_DIR + "/addons.yaml"
+ADDONS_YAML = '%s/addons' % SRC_DIR
 ADDONS_DIR = "/opt/odoo/auto/addons"
 CLEAN = os.environ.get("CLEAN") == "true"
 LINK = os.environ.get("LINK") == "true"
 LOG_LEVELS = ("DEBUG", "INFO", "WARNING", "ERROR")
+
+if os.path.isfile('%s.yaml' % ADDONS_YAML):
+    ADDONS_YAML = '%s.yaml' % ADDONS_YAML
+else:
+    ADDONS_YAML = '%s.yml' % ADDONS_YAML
 
 # Customize logging for build
 logging.root.name = "docker-odoo-base"


### PR DESCRIPTION
* Fix file extension and references to YML

While technically `.yaml` is a valid file extension for YAML, the commonly used one is `.yml` - especially in Docker realm. This proposes that change.

I also made acsone/git-aggregator#14, although technically that just allows it into auto-complete in the shell. You could already use any file format AFAIK.

I will submit another change to your scaffold too once this is accepted.