### PR TITLE
[IMP] Create an addons wildcard

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,6 @@ ONBUILD ARG DEPTH_DEFAULT=1
 ONBUILD ARG DEPTH_MERGE=100
 ONBUILD ARG CLEAN=true
 ONBUILD ARG COMPILE=true
-ONBUILD ARG LINK=true
 ONBUILD ARG PIP_INSTALL_ODOO=true
 ONBUILD ARG ADMIN_PASSWORD=admin
 ONBUILD ARG SMTP_SERVER=smtp
@@ -135,7 +134,8 @@ RUN install.sh
 # Metadata
 ARG VCS_REF
 ARG BUILD_DATE
-LABEL org.label-schema.schema-version="1.0" \
+ARG VERSION
+LABEL org.label-schema.schema-version="$VERSION" \
       org.label-schema.vendor=Tecnativa \
       org.label-schema.license=Apache-2.0 \
       org.label-schema.build-date="$BUILD_DATE" \

--- a/README.md
+++ b/README.md
@@ -162,6 +162,13 @@ server-tools: # Here we repeat server-tools, but no problem because it's a
     - html_text
 ```
 
+You can add all modules in a repo by using a `*`:
+
+```yaml
+website:
+    - "*"
+```
+
 Important notes:
 
 - Do not add repos for the required [`odoo`][] and [`private`][] directories;
@@ -185,6 +192,8 @@ Important notes:
   removed by default, to keep the resulting image thin).
 
 - If you list 2 addons with the same name, you'll get a build error.
+
+- If you use the wildcard (`*`), it must be encapsulated in quotes.
 
 ##### `/opt/odoo/custom/src/requirements.txt`
 

--- a/build.d/30-addons-link
+++ b/build.d/30-addons-link
@@ -16,7 +16,18 @@ logging.info(
     odoobaselib.ADDONS_DIR)
 
 for repo, addons in odoobaselib.addons_config().items():
-    for addon in addons:
+    while addons:
+        addon = addons.pop()
+        if addon == '*':
+            addon_dir = os.path.join(odoobaselib.SRC_DIR, repo)
+            try:
+                modules = next(os.walk(addon_dir))[1]
+            except StopIteration:
+                continue
+            for module in modules:
+                if not module.startswith('.') and module != 'setup':
+                    addons.append(module)
+            continue
         src = os.path.join(odoobaselib.SRC_DIR, repo, addon)
         dst = os.path.join(odoobaselib.ADDONS_DIR, addon)
         logging.debug("Linking %s in %s", src, dst)

--- a/build.d/40-clean
+++ b/build.d/40-clean
@@ -28,6 +28,10 @@ for directory in os.listdir(odoobaselib.SRC_DIR):
         shutil.rmtree(full)
         continue
 
+    # Skip wildcards
+    if '*' in config[directory]:
+        continue
+
     # Traverse addons
     for subdirectory in os.listdir(full):
         subfull = os.path.join(full, subdirectory)

--- a/entrypoint.d/40-addons-link
+++ b/entrypoint.d/40-addons-link
@@ -6,10 +6,6 @@ import sys
 
 import odoobaselib
 
-if not odoobaselib.LINK:
-    logging.warning("Not linking addons")
-    sys.exit()
-
 logging.info(
     "Linking all addons from %s in %s",
     odoobaselib.ADDONS_YAML,

--- a/entrypoint.d/40-addons-link
+++ b/entrypoint.d/40-addons-link
@@ -30,5 +30,6 @@ for repo, addons in odoobaselib.addons_config().items():
             continue
         src = os.path.join(odoobaselib.SRC_DIR, repo, addon)
         dst = os.path.join(odoobaselib.ADDONS_DIR, addon)
-        logging.debug("Linking %s in %s", src, dst)
-        os.symlink(src, dst)
+        if not os.path.exists(dst):
+            logging.debug("Linking %s in %s", src, dst)
+            os.symlink(src, dst)

--- a/lib/odoobaselib.py
+++ b/lib/odoobaselib.py
@@ -9,7 +9,6 @@ SRC_DIR = "/opt/odoo/custom/src"
 ADDONS_YAML = SRC_DIR + "/addons.yaml"
 ADDONS_DIR = "/opt/odoo/auto/addons"
 CLEAN = os.environ.get("CLEAN") == "true"
-LINK = os.environ.get("LINK") == "true"
 LOG_LEVELS = ("DEBUG", "INFO", "WARNING", "ERROR")
 
 # Customize logging for build


### PR DESCRIPTION
This adds a wildcard for the symlinking of modules directories in the `addons.yaml` file, which works out really great for dev instances IMO (or for lazy people, like me).

I tested manually, but didn't really see an obvious way to test via CI. Am I missing something, perhaps?