### PR TITLE
[FIX] Python library permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -120,7 +120,8 @@ RUN mkdir -p auto/addons
 RUN chmod -Rc a+rx \
     common/entrypoint* \
     common/build* \
-    /usr/local/bin
+    /usr/local/bin \
+    /usr/local/lib/python2.7/dist-packages/*.py*
 
 # Execute installation script by Odoo version
 # This is at the end to benefit from cache at build time


### PR DESCRIPTION
* Fix inability for odoo user to access python libraries due to no read/execute

The odoo user is unable to import `odoobaselib` due to no read/execute on the file. This adds read/execute to all `.py*` files in the system libraries & is confirmed to work on what was a previously broken build.

This does admittedly change some files that we did not copy over, but I also don't know of a solid way to determine which libs we need to update specifically.