### PR TITLE
[IMP] Change Odoo user shell to `/bin/false`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM debian:8
 MAINTAINER Tecnativa <info@tecnativa.com>
 
 # Enable Odoo user and filestore
-RUN useradd -md /home/odoo -s /bin/bash odoo \
+RUN useradd -md /home/odoo -s /bin/false odoo \
     && mkdir -p /var/lib/odoo \
     && chown -R odoo:odoo /var/lib/odoo
 VOLUME ["/var/lib/odoo"]


### PR DESCRIPTION
I propose changing the Odoo user's shell to `/bin/false`. Relevant conversation - https://github.com/Tecnativa/docker-odoo-base/commit/3256bc955b50cf277142dd76e633bdca7fcb96e1#commitcomment-22638986

If the quick `su` access is required, maybe we could use a bash alias in the root user?