### PR TITLE
[FIX] Python library permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -120,7 +120,7 @@ COPY conf.d common/conf.d
 COPY entrypoint.d common/entrypoint.d
 RUN mkdir -p auto/addons
 RUN chmod -Rc a+rx common/entrypoint* common/build* /usr/local/bin \
-    && chmod -Rc a+rX /usr/local/lib/python2.7/dist-packages/odoobaselib
+    && chmod -Rc a+rX /usr/local/lib/python2.7/dist-packages/
 
 # Execute installation script by Odoo version
 # This is at the end to benefit from cache at build time


### PR DESCRIPTION
I must insist that we add read and execute on all Python libraries if our intent is to have Odoo running from system Python. Otherwise, there are permissions errors.

* Reapply execute and read permissions for Python libraries (regression of #35)

Error log from a current build:
```
odoo-web_1   | Traceback (most recent call last):
odoo-web_1   |   File "/usr/local/bin/odoo", line 4, in <module>
odoo-web_1   |     __import__('pkg_resources').require('odoo==10.0')
odoo-web_1   |   File "/usr/local/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 3037, in <module>
odoo-web_1   |     @_call_aside
odoo-web_1   |   File "/usr/local/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 3021, in _call_aside
odoo-web_1   |     f(*args, **kwargs)
odoo-web_1   |   File "/usr/local/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 3050, in _initialize_master_working_set
odoo-web_1   |     working_set = WorkingSet._build_master()
odoo-web_1   |   File "/usr/local/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 655, in _build_master
odoo-web_1   |     ws.require(__requires__)
odoo-web_1   |   File "/usr/local/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 969, in require
odoo-web_1   |     needed = self.resolve(parse_requirements(requirements))
odoo-web_1   |   File "/usr/local/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 855, in resolve
odoo-web_1   |     raise DistributionNotFound(req, requirers)
odoo-web_1   | pkg_resources.DistributionNotFound: The 'odoo==10.0' distribution was not found and is required by the application
```