### PR TITLE
[IMP] Add automatic installation of Odoo addons

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,6 +54,7 @@ ARG PYTHONOPTIMIZE=2
 ARG WKHTMLTOPDF_VERSION=0.12.4
 ARG WKHTMLTOPDF_CHECKSUM='049b2cdec9a8254f0ef8ac273afaf54f7e25459a273e27189591edc7d7cf29db'
 ENV OPENERP_SERVER=/opt/odoo/auto/odoo.conf \
+    WAIT_NOHOST='' \
     UNACCENT=true \
     # Git and git-aggregator
     GIT_AUTHOR_NAME=docker-odoo \

--- a/README.md
+++ b/README.md
@@ -315,6 +315,44 @@ now keep this in mind:
 The CLI text editor we all know, just in case you need to inspect some bug in
 hot deployments.
 
+### `install-addons`
+
+This script will iterate the `addons.yml` file to gather support addons, and
+subsequently install to the Odoo instance. It will then exit.
+
+This script is great to use during buildout in order to prepare an instance.
+Below is a minimalistic `docker-compose` file illustrating a use case:
+
+```yaml
+version: '2'
+
+services:
+
+  install:
+    context: ./odoo
+    command: 'install-addons'
+    tty: true
+    depends_on:
+      - db
+
+  web:
+    context: ./odoo
+    restart: unless-stopped
+    tty: true
+    depends_on:
+      - db
+      - install
+    ports:
+      - 8069
+      - 8071
+    environment:
+      WAIT_NOHOST: 'install'
+
+  db:
+    image: postgres:9.6-alpine
+    restart: unless-stopped
+```
+
 ### `log`
 
 Just a little shell script that you can use to add logs to your build or

--- a/bin/install-addons
+++ b/bin/install-addons
@@ -1,0 +1,9 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from odoobaselib import addons_active, do_command
+
+
+do_command(
+    'odoo --stop-after-init -i %s' % ','.join(addons_active())
+)

--- a/entrypoint.d/999-odoo-wait
+++ b/entrypoint.d/999-odoo-wait
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+if [ -z "${WAIT_NOHOST}" ]; then
+    exit 0
+fi
+
+log INFO "Waiting for the Odoo in ${WAIT_NOHOST} to stop"
+
+while ping -c1 "${WAIT_NOHOST}" &> /dev/null; do
+    log DEBUG "${WAIT_NOHOST} responded to ping"
+    sleep 1
+done
+
+log INFO "${WAIT_NOHOST} has stopped responding"
+
+exit 0

--- a/lib/odoobaselib/__init__.py
+++ b/lib/odoobaselib/__init__.py
@@ -34,6 +34,12 @@ else:
 logging.root.setLevel(_log_level)
 
 
+def addons_active():
+    """Returns a list of active addons, as defined in `addons.yml`."""
+    raw_addons = sum(addons_config().values(), [])
+    return filter(lambda x: x != '*', raw_addons)
+
+
 def addons_config():
     """Load configurations from ``ADDONS_YAML`` into a dict."""
     config = dict()


### PR DESCRIPTION
This adds automatic installation of addons that are defined in the `addons.yml` file. It also adds a nifty method to wait on containers to exit, which can be used to allow an install container to be launched before other ones with a `WAIT_CONTAINER` env var as can be seen in my test config:

```yml
services:

 install:
    image: lasley/odoo-buildouts:laslabs-10
    depends_on:
      - db
    tty: true
    environment:
      ADDON_INSTALL: 'true'

 web:
    image: lasley/odoo-buildouts:laslabs-10
    restart: unless-stopped
    depends_on:
      - db
      - install
    tty: true
    ports:
      - 8069
      - 8071
    environment:
      WAIT_CONTAINER: 'install'

  db:
    image: postgres:9.6-alpine
    restart: unless-stopped
    depends_on:
      - db-utils
    environment:
      PGDATA: /var/lib/postgresql/data/pgdata
      POSTGRES_PASSWORD: 'derp'
      POSTGRES_USER: 'odoo'

  db-utils:
    image: grupocitec/pgutils
```