### PR TITLE
fix UID warning for systems with readonly UID

### DIFF
--- a/setup-devel.yaml
+++ b/setup-devel.yaml
@@ -25,7 +25,7 @@ services:
         environment:
             DEPTH_DEFAULT: 100
             # XXX Export these variables before running setup to own the files
-            UID: "$UID"
+            UID: "$DEV_UID"
             GID: "$GID"
             UMASK: "$UMASK"
         user: root


### PR DESCRIPTION
Some linux systems don't allow to modify UID as variable. When used in
.bashrc the warning appears all the time.

After this change. use instead:

     export DEV_UID="$(id -u $USER)" GID="$(id -g $USER)" UMASK="$(umask)"