### PR TITLE
[IMP] Move config generation to entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ ONBUILD ARG DEPTH_DEFAULT=1
 ONBUILD ARG DEPTH_MERGE=100
 ONBUILD ARG CLEAN=true
 ONBUILD ARG COMPILE=true
-ONBUILD ARG CONFIG_BUILD=false
+ONBUILD ARG CONFIG_BUILD=true
 ONBUILD ARG PIP_INSTALL_ODOO=true
 ONBUILD ARG ADMIN_PASSWORD=admin
 ONBUILD ARG SMTP_SERVER=smtp
@@ -115,15 +115,15 @@ WORKDIR /opt/odoo
 RUN pip install --no-cache-dir \
     astor git-aggregator openupgradelib ptvsd==3.0.0 pudb wdb
 COPY bin/* /usr/local/bin/
-COPY bin/direxec.sh common/entrypoint.sh
-RUN ln common/entrypoint.sh common/build.sh
+RUN ln /usr/local/bin/direxec.sh common/build.sh
 COPY lib/odoobaselib /usr/local/lib/python2.7/dist-packages/odoobaselib
 COPY build.d common/build.d
 COPY conf.d common/conf.d
 COPY entrypoint.d common/entrypoint.d
 RUN mkdir -p auto/addons custom/src/private
 RUN chmod -R a+rx common/entrypoint* common/build* /usr/local/bin \
-    && chmod -R a+rX /usr/local/lib/python2.7/dist-packages/odoobaselib
+    && chmod -R a+rX /usr/local/lib/python2.7/dist-packages/odoobaselib \
+    && ln /usr/local/bin/direxec.sh common/entrypoint.sh
 
 # Execute installation script by Odoo version
 # This is at the end to benefit from cache at build time

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,10 +28,16 @@ ONBUILD ARG PGUSER=odoo
 ONBUILD ARG PGPASSWORD=odoopassword
 ONBUILD ARG PGHOST=db
 ONBUILD ARG PGDATABASE=prod
-ONBUILD ENV PGUSER="$PGUSER" \
+# Config variables
+ONBUILD ENV ADMIN_PASSWORD="$ADMIN_PASSWORD" \
+            UNACCENT="$UNACCENT" \
+            PGUSER="$PGUSER" \
             PGPASSWORD="$PGPASSWORD" \
             PGHOST="$PGHOST" \
-            PGDATABASE="$PGDATABASE"
+            PGDATABASE="$PGDATABASE" \
+            PROXY_MODE="$PROXY_MODE" \
+            SMTP_SERVER="$SMTP_SERVER" \
+            WITHOUT_DEMO="$WITHOUT_DEMO"
 ONBUILD ARG LOCAL_CUSTOM_DIR=./custom
 ONBUILD COPY $LOCAL_CUSTOM_DIR /opt/odoo/custom
 # https://docs.python.org/2.7/library/logging.html#levels

--- a/Dockerfile
+++ b/Dockerfile
@@ -121,15 +121,15 @@ WORKDIR /opt/odoo
 RUN pip install --no-cache-dir \
     astor git-aggregator openupgradelib ptvsd==3.0.0 pudb wdb
 COPY bin/* /usr/local/bin/
-RUN ln /usr/local/bin/direxec.sh common/build.sh
 COPY lib/odoobaselib /usr/local/lib/python2.7/dist-packages/odoobaselib
 COPY build.d common/build.d
 COPY conf.d common/conf.d
 COPY entrypoint.d common/entrypoint.d
-RUN mkdir -p auto/addons custom/src/private
-RUN chmod -R a+rx common/entrypoint* common/build* /usr/local/bin \
-    && chmod -R a+rX /usr/local/lib/python2.7/dist-packages/odoobaselib \
-    && ln /usr/local/bin/direxec.sh common/entrypoint.sh
+RUN mkdir -p auto/addons custom/src/private \
+    && ln /usr/local/bin/direxec.sh common/entrypoint.sh \
+    && ln /usr/local/bin/direxec.sh common/build.sh \
+    && chmod -R a+rx common/entrypoint* common/build* /usr/local/bin \
+    && chmod -R a+rX /usr/local/lib/python2.7/dist-packages/odoobaselib
 
 # Execute installation script by Odoo version
 # This is at the end to benefit from cache at build time

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ ONBUILD ARG DEPTH_DEFAULT=1
 ONBUILD ARG DEPTH_MERGE=100
 ONBUILD ARG CLEAN=true
 ONBUILD ARG COMPILE=true
+ONBUILD ARG CONFIG_BUILD=false
 ONBUILD ARG PIP_INSTALL_ODOO=true
 ONBUILD ARG ADMIN_PASSWORD=admin
 ONBUILD ARG SMTP_SERVER=smtp
@@ -113,7 +114,7 @@ RUN curl -SLo wkhtmltox.tar.xz https://github.com/wkhtmltopdf/wkhtmltopdf/releas
 WORKDIR /opt/odoo
 RUN pip install --no-cache-dir \
     astor git-aggregator openupgradelib ptvsd==3.0.0 pudb wdb
-COPY bin/autoaggregate bin/install.sh bin/log bin/pot bin/python-odoo-shell bin/unittest /usr/local/bin/
+COPY bin/* /usr/local/bin/
 COPY bin/direxec.sh common/entrypoint.sh
 RUN ln common/entrypoint.sh common/build.sh
 COPY lib/odoobaselib /usr/local/lib/python2.7/dist-packages/odoobaselib

--- a/bin/config-generate
+++ b/bin/config-generate
@@ -1,0 +1,9 @@
+#!/bin/bash
+# Generate Odoo server configuration from templates
+set -e
+src="/opt/odoo/common/conf.d/* /opt/odoo/custom/conf.d/*"
+log INFO Merging $(ls $src | wc -l) configuration files in $OPENERP_SERVER
+conf=$(cat $src | envsubst)
+log DEBUG "Resulting configuration:
+$conf"
+echo "$conf" > $OPENERP_SERVER

--- a/build.d/60-config-generate
+++ b/build.d/60-config-generate
@@ -1,9 +1,8 @@
 #!/bin/bash
-# Generate Odoo server configuration from templates
-set -e
-src="/opt/odoo/common/conf.d/* /opt/odoo/custom/conf.d/*"
-log INFO Merging $(ls $src | wc -l) configuration files in $OPENERP_SERVER
-conf=$(cat $src | envsubst)
-log DEBUG "Resulting configuration:
-$conf"
-echo "$conf" > $OPENERP_SERVER
+
+if [ "${CONFIG_BUILD}" != true ]; then
+    log WARNING Skipping Odoo config generation - will perform during entrypoint.
+    exit 0
+fi
+
+config-generate

--- a/build.d/60-config-generate
+++ b/build.d/60-config-generate
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [ "${CONFIG_BUILD}" != true ]; then
+if [ "${CONFIG_BUILD}" != "true" ]; then
     log WARNING Skipping Odoo config generation - will perform during entrypoint.
     exit 0
 fi

--- a/entrypoint.d/50-config-generate
+++ b/entrypoint.d/50-config-generate
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+if [ "${CONFIG_BUILD}" = true ]; then
+    log WARNING Skipping Odoo config generation - performed at build time.
+    exit 0
+fi
+
+config-generate

--- a/entrypoint.d/50-config-generate
+++ b/entrypoint.d/50-config-generate
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-if [ "${CONFIG_BUILD}" = true ]; then
-    log WARNING Skipping Odoo config generation - performed at build time.
+if [ -f  "${OPENERP_SERVER}" ]; then
+    log INFO File $OPENERP_SERVER exists, skipping config generation
     exit 0
 fi
 

--- a/tests/scaffoldings/dotd/docker-compose.yaml
+++ b/tests/scaffoldings/dotd/docker-compose.yaml
@@ -4,12 +4,18 @@ services:
         build:
             context: ./
             dockerfile: ${ODOO_MINOR}.Dockerfile
+            args:
+              CONFIG_BUILD: 'false'
         tty: true
+        environment:
+          PGUSER: another_odoo
+          PGPASSWORD: anotherodoopassword
+          PGHOST: postgresql
         depends_on:
-            - db
+            - postgresql
 
-    db:
+    postgresql:
         image: postgres:${DB_VERSION}-alpine
         environment:
-            POSTGRES_USER: odoo
-            POSTGRES_PASSWORD: odoopassword
+            POSTGRES_USER: another_odoo
+            POSTGRES_PASSWORD: anotherodoopassword


### PR DESCRIPTION
Turns out I never made any of the requested changes to remove the backwards compatibility in my forked image (hooray Git and laziness!). Resubmitting #37 in its original form, which is backwards compatible.

I'll still need to add a test for generating it on entrypoint. Should I just choose one of the scaffolds randomly, or do you have some sort of pattern you're going for with them in terms of what they test?

Fix #37