### PR TITLE
Added workers for production environment to enable longpolling

### DIFF
--- a/prod.yaml
+++ b/prod.yaml
@@ -13,6 +13,9 @@ services:
             - db
             - smtp
             - inbox
+        command:
+            - odoo
+            - --workers=2
         networks:
             default:
             inverseproxy_shared:


### PR DESCRIPTION
First off a huge thank you for sharing this jewel. I've started using it on everything and life has become at least 5 times easier since.

As I don't have your expertise with Docker my PR's would be more on the line of humble suggestions than anything else.

Regarding the production environment it is mentioned in the doc that it needs quite a bit of customization but I thought that adding a minimum amount of workers to enable longpolling would be great.

I was not aware if I had a nginx configuration issue or something else before realizing that I did not deploy workers as longpolling was not working.

If the command is in the production environment the user can easily increase/decrease workers or add other extra commands.

I'm aware you can also place this in the configuration file but it's up to you to decide if it's worthwhile.