### PR TITLE
Update backup and config generation systems

### DIFF
--- a/.env
+++ b/.env
@@ -36,16 +36,9 @@ INBOX_REAL_LISTEN=:995
 INBOX_REAL_TALK=inbox.example.com:995
 
 # Backup
-BACKUP_ROOT_EMAIL_FROM=backup@example.com
-BACKUP_ROOT_EMAIL_TO=alerts@example.com
 BACKUP_S3_ACCESS_KEY=example key
 BACKUP_S3_SECRET_KEY=example secret
 BACKUP_S3_BUCKET=example-bkp
-BACKUP_S3_INSTANCE=docker-example
-BACKUP_SEND_MAIL_ERR=1
-BACKUP_SEND_MAIL_LOG=1
-BACKUP_EMAIL_SUBJECT=[EXAMPLE]
 BACKUP_EMAIL_FROM=backup@example.com
 BACKUP_EMAIL_TO=alerts@example.com
-BACKUP_ENCRYPT=1
 BACKUP_ENCRYPT_KEY=example encryption key

--- a/common.yaml
+++ b/common.yaml
@@ -58,25 +58,18 @@ services:
             TALK: "$INBOX_REAL_TALK"
 
     backup:
-        image: tecnativa/server-backup
+        image: tecnativa/duplicity:postgres-s3
+        hostname: backup
+        domainname: "$DOMAIN_PROD"
         environment:
-            MAIL_RELAY_HOST: smtp
-            ROOT_EMAIL_FROM: "$BACKUP_ROOT_EMAIL_FROM"
-            ROOT_EMAIL_TO: "$BACKUP_ROOT_EMAIL_TO"
-            BACKUP_S3_ACCESS_KEY: "$BACKUP_S3_ACCESS_KEY"
-            BACKUP_S3_SECRET_KEY: "$BACKUP_S3_SECRET_KEY"
-            BACKUP_S3_BUCKET: "$BACKUP_S3_BUCKET"
-            BACKUP_S3_INSTANCE: "$BACKUP_S3_INSTANCE"
-            BACKUP_SEND_MAIL_ERR: "$BACKUP_SEND_MAIL_ERR"
-            BACKUP_SEND_MAIL_LOG: "$BACKUP_SEND_MAIL_LOG"
-            BACKUP_EMAIL_SUBJECT: "$BACKUP_EMAIL_SUBJECT"
-            BACKUP_EMAIL_FROM: "$BACKUP_EMAIL_FROM"
-            BACKUP_EMAIL_TO: "$BACKUP_EMAIL_TO"
-            BACKUP_ENCRYPT: "$BACKUP_ENCRYPT"
-            BACKUP_ENCRYPT_KEY: "$BACKUP_ENCRYPT_KEY"
-            BACKUP_SOURCES: /var/lib/odoo,0,1
-            PG_HOST: db
-            PG_USER: "$DB_USER"
-            PG_PASS: "$DB_PASSWORD"
+            AWS_ACCESS_KEY_ID: "$BACKUP_S3_ACCESS_KEY"
+            AWS_SECRET_ACCESS_KEY: "$BACKUP_S3_SECRET_KEY"
+            DST: "s3://s3.amazonaws.com/$BACKUP_S3_BUCKET"
+            EMAIL_FROM: "$BACKUP_EMAIL_FROM"
+            EMAIL_TO: "$BACKUP_EMAIL_TO"
+            PASSPHRASE: "$BACKUP_ENCRYPT_KEY"
+            PGDATABASE: prod
+            PGPASSWORD: "$DB_PASSWORD"
+            PGUSER: "$DB_USER"
         volumes:
-            - filestore$ODOO_MAJOR:/var/lib/odoo:z
+            - filestore$ODOO_MAJOR:/mnt/backup/src/odoo:z

--- a/common.yaml
+++ b/common.yaml
@@ -4,8 +4,13 @@ services:
         build:
             context: ./odoo
             args:
-                PGUSER: "$DB_USER"
-                PGPASSWORD: "$DB_PASSWORD"
+                CONFIG_BUILD: "false"
+        environment:
+            ADMIN_PASSWORD: "$ODOO_ADMIN_PASSWORD"
+            PGPASSWORD: "$DB_PASSWORD"
+            PGUSER: "$DB_USER"
+            PROXY_MODE: "$ODOO_PROXY_MODE"
+            PYTHONOPTIMIZE: 2
         tty: true
         volumes:
             - filestore$ODOO_MAJOR:/var/lib/odoo:z

--- a/devel.yaml
+++ b/devel.yaml
@@ -7,16 +7,18 @@ services:
             service: odoo
         build:
             args:
-                PGDATABASE: devel
                 # To aggregate in development, use `setup-devel.yaml`
                 AGGREGATE: "false"
                 # No need for this in development
-                PYTHONOPTIMIZE: 0
                 PIP_INSTALL_ODOO: "false"
                 CLEAN: "false"
                 COMPILE: "false"
-                # You want demo data for development
-                WITHOUT_DEMO: "false"
+        environment:
+            ADMIN_PASSWORD: admin
+            PGDATABASE: devel
+            PYTHONOPTIMIZE: ""
+            # You want demo data for development
+            WITHOUT_DEMO: "false"
         ports:
             - "127.0.0.1:${ODOO_MAJOR}069:8069"
             - "127.0.0.1:${ODOO_MAJOR}072:8072"

--- a/prod.yaml
+++ b/prod.yaml
@@ -4,10 +4,6 @@ services:
         extends:
             file: common.yaml
             service: odoo
-        build:
-            args:
-                ADMIN_PASSWORD: "$ODOO_ADMIN_PASSWORD"
-                PROXY_MODE: "$ODOO_PROXY_MODE"
         restart: unless-stopped
         depends_on:
             - db

--- a/test.yaml
+++ b/test.yaml
@@ -4,13 +4,10 @@ services:
         extends:
             file: common.yaml
             service: odoo
-        build:
-            args:
-                ADMIN_PASSWORD: "$ODOO_ADMIN_PASSWORD"
-                PGDATABASE: test
-                PROXY_MODE: "$ODOO_PROXY_MODE"
-                # You may want demo data for testing
-                WITHOUT_DEMO: "false"
+        environment:
+            PGDATABASE: test
+            # You may want demo data for testing
+            WITHOUT_DEMO: "false"
         depends_on:
             - db
             - smtp


### PR DESCRIPTION
- Use tecnativa/duplicity:postgres-s3 backup image by default.
- Use new entrypoint configuration generation system from #60.
- Fix #63.