### PR TITLE
Add ~/.local/bin to $PATH

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -71,7 +71,8 @@ ENV OPENERP_SERVER=/opt/odoo/auto/odoo.conf \
     WDB_WEB_PORT=1984 \
     WDB_WEB_SERVER=localhost \
     # Other
-    LC_ALL=C.UTF-8
+    LC_ALL=C.UTF-8 \
+    PATH="~/.local/bin:$PATH"
 
 # Other requirements and recommendations to run Odoo
 # See https://github.com/$ODOO_SOURCE/blob/$ODOO_VERSION/debian/control

--- a/tests/scaffoldings/dotd/custom/entrypoint.d/pip-install-user
+++ b/tests/scaffoldings/dotd/custom/entrypoint.d/pip-install-user
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -ex
+
+# Check that --user installations work
+pip install --user pg_activity
+
+# Binary must be in $PATH
+pg_activity --version


### PR DESCRIPTION
This makes binaries installed by `pip install --user` become directly usable and fixes #76.