### PR TITLE
[DCK] No volume versions

### DIFF
--- a/common.yaml
+++ b/common.yaml
@@ -13,7 +13,7 @@ services:
             PYTHONOPTIMIZE: 2
         tty: true
         volumes:
-            - filestore$ODOO_MAJOR:/var/lib/odoo:z
+            - filestore:/var/lib/odoo:z
         labels:
             traefik.docker.network: "inverseproxy_shared"
             traefik.enable: "true"
@@ -27,7 +27,7 @@ services:
             POSTGRES_USER: "$DB_USER"
             POSTGRES_PASSWORD: "$DB_PASSWORD"
         volumes:
-            - db$ODOO_MAJOR:/var/lib/postgresql/data:z
+            - db:/var/lib/postgresql/data:z
 
     smtpfake:
         image: tecnativa/smtp-sink
@@ -72,4 +72,4 @@ services:
             PGPASSWORD: "$DB_PASSWORD"
             PGUSER: "$DB_USER"
         volumes:
-            - filestore$ODOO_MAJOR:/mnt/backup/src/odoo:z
+            - filestore:/mnt/backup/src/odoo:z

--- a/devel.yaml
+++ b/devel.yaml
@@ -58,6 +58,5 @@ services:
             - "127.0.0.1:1984:1984"
 
 volumes:
-    # XXX Odoo volume names must match $ODOO_MAJOR for quick branch switching
-    filestore10:
-    db10:
+    filestore:
+    db:

--- a/prod.yaml
+++ b/prod.yaml
@@ -63,7 +63,6 @@ networks:
         external: true
 
 volumes:
-    # XXX Odoo volume names must match $ODOO_MAJOR for quick branch switching
-    filestore10:
-    db10:
+    filestore:
+    db:
     smtp:

--- a/test.yaml
+++ b/test.yaml
@@ -56,6 +56,5 @@ networks:
         external: true
 
 volumes:
-    # XXX Odoo volume names must match $ODOO_MAJOR for quick branch switching
-    filestore10:
-    db10:
+    filestore:
+    db:


### PR DESCRIPTION
This is a **breaking change**.

The purpose of this feature was that you were able to quickly switch branches in the project by using git, and avoid different branches to share the same volumes, since that can lead to errors in different Odoo versions.

At the end of the day, it turns out that feature was not used. Most version switching happens in devel, where you'd have to re-run `setup-devel` stuff, which slowed down the devel process too much.

Other version switches happened when running OpenUpgrade among versions, and in these cases we need to share the same volume among versions, so this "feature" was becoming a "bug".

So, finally we decided to drop it. This eases the initial scaffolding setup (less things to change). If we need different versions, it's as easy as having different clones, one on each branch, or switching the env `COMPOSE_PROJECT` variable.