### PR TITLE
Fix build by pinning PhantomJS version

### DIFF
--- a/8.0.Dockerfile
+++ b/8.0.Dockerfile
@@ -104,7 +104,7 @@ RUN gem install --no-rdoc --no-ri --no-update-sources bootstrap-sass --version '
 
 # Special case for PhantomJS
 RUN ln -s /usr/bin/nodejs /usr/local/bin/node \
-    && npm install -g phantomjs-prebuilt \
+    && npm install -g phantomjs-prebuilt@2.1.15 \
     && rm -Rf ~/.npm /tmp/*
 
 # Special case for wkhtmltox


### PR DESCRIPTION
It seems phantomjs > 2.1.15 does not install in Debian 8 anymore.

This should fix builds for tags 8.0, 9.0 and 10.0.