### PR TITLE
[IMP] Ensure dependencies installation replicability.

### DIFF
--- a/build.d/200-dependencies
+++ b/build.d/200-dependencies
@@ -1,8 +1,9 @@
 #!/usr/bin/env python
 # Copyright 2017 LasLabs Inc.
 
-from os.path import join
+from os.path import basename, join, splitext
 from glob import glob
+import logging
 
 from odoobaselib import (
     AUTO_REQUIREMENTS,
@@ -25,3 +26,14 @@ for name in INSTALLERS:
     req_files.append(join(CUSTOM_DIR, 'dependencies', '%s.txt' % name))
     for req_file in req_files:
         install(name, req_file)
+
+# Sorted dependencies installation
+dep_files = sorted(glob(join(CUSTOM_DIR, 'dependencies', '[0-9]*-*')))
+for dep_file in dep_files:
+    root, ext = splitext(basename(dep_file))
+    # Get the installer (xxx-installer[-description][.ext])
+    installer = root.split('-', 2)[1]
+    if installer not in INSTALLERS:
+        logging.error("Unknown installer: %s", installer)
+        raise Exception
+    install(installer, dep_file)

--- a/lib/odoobaselib/installer.py
+++ b/lib/odoobaselib/installer.py
@@ -119,4 +119,3 @@ INSTALLERS = OrderedDict([
 def install(installer, file_path):
     """Perform a given type of installation from a given file."""
     return INSTALLERS[installer](file_path).install()
-

--- a/lib/odoobaselib/installer.py
+++ b/lib/odoobaselib/installer.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from collections import OrderedDict
 from os.path import exists
 from subprocess import check_call
 from odoobaselib import logging
@@ -107,14 +108,15 @@ class PipInstaller(Installer):
         return [self.file_path] if exists(self.file_path) else []
 
 
-INSTALLERS = {
-    "apt": AptInstaller,
-    "gem": GemInstaller,
-    "npm": NpmInstaller,
-    "pip": PipInstaller,
-}
+INSTALLERS = OrderedDict([
+    ("apt", AptInstaller),
+    ("gem", GemInstaller),
+    ("npm", NpmInstaller),
+    ("pip", PipInstaller),
+])
 
 
 def install(installer, file_path):
     """Perform a given type of installation from a given file."""
     return INSTALLERS[installer](file_path).install()
+

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -302,7 +302,7 @@ class ScaffoldingCase(unittest.TestCase):
                     )
                 # Test all 3 official environments
                 for dcfile in ("devel", "test", "prod"):
-                    sub_env["COMPOSE_FILE"] = f"{dcfile}.yaml"
+                    sub_env["COMPOSE_FILE"] = "{}.yaml".format(dcfile)
                     self.compose_test(
                         tmpdirname, sub_env,
                         # ``odoo`` command works

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -234,6 +234,37 @@ class ScaffoldingCase(unittest.TestCase):
                 ("--version",),
             )
 
+    def test_dependencies(self):
+        """Test dependencies installation."""
+        dependencies_dir = join(SCAFFOLDINGS_DIR, "dependencies")
+        for sub_env in matrix():
+            self.compose_test(
+                dependencies_dir, sub_env,
+                ("test", "!", "-f", "custom/dependencies/apt.txt"),
+                ("test", "!", "-f", "custom/dependencies/gem.txt"),
+                ("test", "!", "-f", "custom/dependencies/npm.txt"),
+                ("test", "!", "-f", "custom/dependencies/pip.txt"),
+                # apt_build.txt
+                ("test", "-f", "custom/dependencies/apt_build.txt"),
+                ("test", "!", "-e", "/usr/bin/gcc"),
+                # apt-without-sequence.txt
+                ("test", "-f", "custom/dependencies/apt-without-sequence.txt"),
+                ("test", "!", "-e", "/bin/busybox"),
+                # 070-apt-bc.txt
+                ("test", "-f", "custom/dependencies/070-apt-bc.txt"),
+                ("test", "-e", "/usr/bin/bc"),
+                # 150-npm-aloha_world-install.txt
+                ("test", "-f", "custom/dependencies/150-npm-aloha_world-install.txt"),
+                ("node", "-e", "require('test-npm-install')"),
+                # 200-pip-without-ext
+                ("test", "-f", "custom/dependencies/200-pip-without-ext"),
+                ("python", "-c", "import Crypto; print(Crypto.__version__)"),
+                ("sh", "-c", "rst2html.py --version | grep 'Docutils 0.14'"),
+                # 270-gem.txt
+                ("test", "-f", "custom/dependencies/270-gem.txt"),
+                ("aloha_world",),
+            )
+
     @unittest.skipUnless(
         MAIN_SCAFFOLDING_VERSION in ODOO_VERSIONS,
         "Main scaffolding version is not being tested")

--- a/tests/scaffoldings/dependencies/10.0.Dockerfile
+++ b/tests/scaffoldings/dependencies/10.0.Dockerfile
@@ -1,0 +1,1 @@
+FROM tecnativa/odoo-base:10.0

--- a/tests/scaffoldings/dependencies/11.0.Dockerfile
+++ b/tests/scaffoldings/dependencies/11.0.Dockerfile
@@ -1,0 +1,1 @@
+FROM tecnativa/odoo-base:11.0

--- a/tests/scaffoldings/dependencies/8.0.Dockerfile
+++ b/tests/scaffoldings/dependencies/8.0.Dockerfile
@@ -1,0 +1,1 @@
+FROM tecnativa/odoo-base:8.0

--- a/tests/scaffoldings/dependencies/9.0.Dockerfile
+++ b/tests/scaffoldings/dependencies/9.0.Dockerfile
@@ -1,0 +1,1 @@
+FROM tecnativa/odoo-base:9.0

--- a/tests/scaffoldings/dependencies/custom/dependencies/070-apt-bc.txt
+++ b/tests/scaffoldings/dependencies/custom/dependencies/070-apt-bc.txt
@@ -1,0 +1,2 @@
+# This line should be ignored
+bc

--- a/tests/scaffoldings/dependencies/custom/dependencies/150-npm-aloha_world-install.txt
+++ b/tests/scaffoldings/dependencies/custom/dependencies/150-npm-aloha_world-install.txt
@@ -1,0 +1,2 @@
+# This line should be ignored
+test-npm-install

--- a/tests/scaffoldings/dependencies/custom/dependencies/200-pip-without-ext
+++ b/tests/scaffoldings/dependencies/custom/dependencies/200-pip-without-ext
@@ -1,0 +1,4 @@
+# Compiled locally, which would fail if `apt_build.txt` fails
+pycrypto==2.6.1 --no-binary :all:
+# Odoo pins docutils==0.12, so let's check it gets upgraded
+docutils==0.14

--- a/tests/scaffoldings/dependencies/custom/dependencies/270-gem.txt
+++ b/tests/scaffoldings/dependencies/custom/dependencies/270-gem.txt
@@ -1,0 +1,2 @@
+# This line should be ignored
+aloha_world

--- a/tests/scaffoldings/dependencies/custom/dependencies/apt-without-sequence.txt
+++ b/tests/scaffoldings/dependencies/custom/dependencies/apt-without-sequence.txt
@@ -1,0 +1,2 @@
+# This package WON'T be installed
+busybox

--- a/tests/scaffoldings/dependencies/custom/dependencies/apt_build.txt
+++ b/tests/scaffoldings/dependencies/custom/dependencies/apt_build.txt
@@ -1,0 +1,5 @@
+# This installs gcc among other things
+build-essential
+# This is the basic need to build any python extensions
+python-dev
+python3-dev

--- a/tests/scaffoldings/dependencies/custom/src/repos.yaml
+++ b/tests/scaffoldings/dependencies/custom/src/repos.yaml
@@ -1,0 +1,12 @@
+# Odoo is always required
+./odoo:
+    defaults:
+        # Shallow repositores are faster & thinner
+        depth: $DEPTH_DEFAULT
+    remotes:
+        ocb: https://github.com/OCA/OCB.git
+        odoo: https://github.com/odoo/odoo.git
+    target:
+        ocb $ODOO_VERSION
+    merges:
+        - ocb $ODOO_VERSION

--- a/tests/scaffoldings/dependencies/docker-compose.yaml
+++ b/tests/scaffoldings/dependencies/docker-compose.yaml
@@ -1,0 +1,29 @@
+version: "2.1"
+services:
+  odoo:
+    build:
+      context: ./
+      dockerfile: ${ODOO_MINOR}.Dockerfile
+      args:
+        COMPILE: "false"
+        WITHOUT_DEMO: "false"
+    tty: true
+    depends_on:
+      - db
+    environment:
+      PYTHONOPTIMIZE: ""
+      UNACCENT: "false"
+    volumes:
+      - filestore:/var/lib/odoo:z
+
+  db:
+    image: postgres:${DB_VERSION}-alpine
+    environment:
+      POSTGRES_USER: odoo
+      POSTGRES_PASSWORD: odoopassword
+    volumes:
+      - db:/var/lib/postgresql/data:z
+
+volumes:
+  db:
+  filestore:


### PR DESCRIPTION
Use `OrderedDict` instead of `dict` to ensure the same installation priority between builds (apt > gem > npm > pip) in [build.d/200-dependencies](/Tecnativa/docker-odoo-base/blob/master/build.d/200-dependencies).

This change also ensures that `pip install` dependencies' can be installed through Debian's `apt` (e.g.: `lxml` -> `libxml2-dev libxslt1-dev`).