### PR TITLE
[NEW] convert smtpfake to mailhog catcher

### DIFF
--- a/common.yaml
+++ b/common.yaml
@@ -30,7 +30,7 @@ services:
             - db:/var/lib/postgresql/data:z
 
     smtpfake:
-        image: tecnativa/smtp-sink
+        image: mailhog/mailhog
 
     smtpreal:
         image: tecnativa/postfix-relay

--- a/devel.yaml
+++ b/devel.yaml
@@ -54,7 +54,6 @@ services:
             file: common.yaml
             service: smtpfake
         ports:
-            - "127.0.0.1:1025:1025"
             - "127.0.0.1:8025:8025"
 
     wdb:

--- a/devel.yaml
+++ b/devel.yaml
@@ -51,6 +51,8 @@ services:
         extends:
             file: common.yaml
             service: smtpfake
+        ports:
+            - "127.0.0.1:8025:8025"
 
     wdb:
         image: yajo/wdb-server

--- a/devel.yaml
+++ b/devel.yaml
@@ -17,7 +17,6 @@ services:
             ADMIN_PASSWORD: admin
             PGDATABASE: devel
             PYTHONOPTIMIZE: ""
-            SMTP_SERVER: "smtp"
             SMTP_PORT: "1025"
             # You want demo data for development
             WITHOUT_DEMO: "false"

--- a/devel.yaml
+++ b/devel.yaml
@@ -52,6 +52,7 @@ services:
             file: common.yaml
             service: smtpfake
         ports:
+            - "127.0.0.1:1025:1025"
             - "127.0.0.1:8025:8025"
 
     wdb:

--- a/devel.yaml
+++ b/devel.yaml
@@ -17,6 +17,8 @@ services:
             ADMIN_PASSWORD: admin
             PGDATABASE: devel
             PYTHONOPTIMIZE: ""
+            SMTP_SERVER: "smtp"
+            SMTP_PORT: "1025"
             # You want demo data for development
             WITHOUT_DEMO: "false"
         ports:

--- a/test.yaml
+++ b/test.yaml
@@ -8,6 +8,8 @@ services:
             PGDATABASE: test
             # You may want demo data for testing
             WITHOUT_DEMO: "false"
+            SMTP_SERVER: "smtp"
+            SMTP_PORT: "1025"
         depends_on:
             - db
             - smtp

--- a/test.yaml
+++ b/test.yaml
@@ -8,7 +8,6 @@ services:
             PGDATABASE: test
             # You may want demo data for testing
             WITHOUT_DEMO: "false"
-            SMTP_SERVER: "smtp"
             SMTP_PORT: "1025"
         depends_on:
             - db

--- a/test.yaml
+++ b/test.yaml
@@ -48,6 +48,15 @@ services:
         extends:
             file: common.yaml
             service: smtpfake
+        networks:
+            default:
+            inverseproxy_shared:
+        labels:
+            traefik.docker.network: "inverseproxy_shared"
+            traefik.enable: "true"
+            traefik.frontend.passHostHeader: "true"
+            traefik.port: "8025"
+            traefik.frontend.rule: "Host:${DOMAIN_TEST};PathPrefixStrip:/smtpfake/"
 
 networks:
     default:


### PR DESCRIPTION
Use mailhog as smtp catcher for dev environment

- fix #101 

WIP until:

- [x] #110

**howto**: when docker-compose -f devel.yaml up, go to http://localhost:8025 to have mailhog.