### PR TITLE
[IMP] Add note about `autoupdate` module requirements

### DIFF
--- a/bin/autoupdate
+++ b/bin/autoupdate
@@ -1,3 +1,5 @@
 #!/usr/local/bin/python-odoo-shell
+
+# Note: ``module_auto_update`` must be installed in Odoo for this to work.
 env["base.module.upgrade"].upgrade_module()
 env.cr.commit()


### PR DESCRIPTION
* `bin/autoupdate` requires that `module_auto_update` is installed in Odoo. Add a comment to remind us.