### PR TITLE
[DCK] Remove inbox containers, use internal networks

### DIFF
--- a/.env
+++ b/.env
@@ -27,14 +27,6 @@ SMTP_REAL_RELAY_PASS=example password
 SMTP_REAL_CANONICAL_DOMAINS=example.com
 SMTP_REAL_NON_CANONICAL_DEFAULT=example.com
 
-# Fake IMAP/POP3 server
-INBOX_FAKE_LISTEN=:995
-INBOX_FAKE_TALK=inbox.example.com:995
-
-# Real IMAP/POP3 server
-INBOX_REAL_LISTEN=:995
-INBOX_REAL_TALK=inbox.example.com:995
-
 # Backup
 BACKUP_S3_ACCESS_KEY=example key
 BACKUP_S3_SECRET_KEY=example secret

--- a/common.yaml
+++ b/common.yaml
@@ -45,18 +45,6 @@ services:
             MAIL_CANONICAL_DOMAINS: "$SMTP_REAL_CANONICAL_DOMAINS"
             MAIL_NON_CANONICAL_DEFAULT: "$SMTP_REAL_NON_CANONICAL_DEFAULT"
 
-    inboxfake:
-        image: tecnativa/tcp-proxy
-        environment:
-            LISTEN: "$INBOX_FAKE_LISTEN"
-            TALK: "$INBOX_FAKE_TALK"
-
-    inboxreal:
-        image: tecnativa/tcp-proxy
-        environment:
-            LISTEN: "$INBOX_REAL_LISTEN"
-            TALK: "$INBOX_REAL_TALK"
-
     backup:
         image: tecnativa/duplicity:postgres-s3
         hostname: backup

--- a/devel.yaml
+++ b/devel.yaml
@@ -43,11 +43,6 @@ services:
             file: common.yaml
             service: db
 
-    inbox:
-        extends:
-            file: common.yaml
-            service: inboxfake
-
     smtp:
         extends:
             file: common.yaml
@@ -59,6 +54,10 @@ services:
         image: yajo/wdb-server
         ports:
             - "127.0.0.1:1984:1984"
+
+networks:
+    default:
+        internal: true
 
 volumes:
     filestore:

--- a/prod.yaml
+++ b/prod.yaml
@@ -33,12 +33,6 @@ services:
             service: db
         restart: unless-stopped
 
-    inbox:
-        extends:
-            file: common.yaml
-            service: inboxreal
-        restart: unless-stopped
-
     smtp:
         extends:
             file: common.yaml

--- a/setup-devel.yaml
+++ b/setup-devel.yaml
@@ -20,6 +20,8 @@ services:
                 PIP_INSTALL_ODOO: "false"
                 CLEAN: "false"
                 COMPILE: "false"
+        networks:
+            - public
         volumes:
             - ./odoo/custom/src:/opt/odoo/custom/src:rw,z
         environment:
@@ -30,3 +32,6 @@ services:
             UMASK: "$UMASK"
         user: root
         entrypoint: autoaggregate
+
+networks:
+    public:

--- a/test.yaml
+++ b/test.yaml
@@ -40,11 +40,6 @@ services:
             file: common.yaml
             service: db
 
-    inbox:
-        extends:
-            file: common.yaml
-            service: inboxfake
-
     smtp:
         extends:
             file: common.yaml
@@ -61,6 +56,7 @@ services:
 
 networks:
     default:
+        internal: true
         driver_opts:
             encrypted: 1
 


### PR DESCRIPTION
The inbox proxies were a trick to isolate POP3/IMAP (or any other TCP) connections when a database got restored into a non-production environment.

Since Docker 1.10, internal networks are natively supported, which means that any in/out communication outside the container stack gets automatically blocked.

From now on, you can just configure incoming mail as usual in your Odoo instances with the safety that those incoming mails will not be read outside the production environment.

If you still need outside world communication for devel or test environments, you can enable it by switching the internal boolean, or by adding a public network with public access and attaching it to the containers that need it (usually just Odoo).

Note that for this to have a real effect, the `inverseproxy_shared` network must be internal too in test environments.

Fixes #98