### PR TITLE
Multiple with and without calls instead of comma-separating

### DIFF
--- a/bin/addons
+++ b/bin/addons
@@ -44,16 +44,16 @@ parser.add_argument(
     "-x", "--explicit", action="store_true",
     help="Fail if any addon is explicitly declared but not found")
 parser.add_argument(
-    "-w", "--with", action="store", dest="with_", default="",
-    help="Comma-separated list of addons to include always.")
+    "-w", "--with", action="append", dest="with_",
+    help="Addons to include always.")
 parser.add_argument(
-    "-W", "--without", action="store", default="",
-    help="Comma-separated list of addons to exclude always.")
+    "-W", "--without", action="append",
+    help="Addons to exclude always.")
 
 # Generate the matching addons set
 args = parser.parse_args()
-addons = set(args.with_.split(",")) - {""}
-without = set(args.without.split(",")) - {""}
+addons = set(args.with_)
+without = set(args.without)
 if addons & without:
     sys.exit("Cannot include and exclude the same addon!")
 for addon, repo in addons_config(strict=args.explicit):

--- a/bin/addons
+++ b/bin/addons
@@ -44,10 +44,10 @@ parser.add_argument(
     "-x", "--explicit", action="store_true",
     help="Fail if any addon is explicitly declared but not found")
 parser.add_argument(
-    "-w", "--with", action="append", dest="with_",
+    "-w", "--with", action="append", dest="with_", default=[],
     help="Addons to include always.")
 parser.add_argument(
-    "-W", "--without", action="append",
+    "-W", "--without", action="append", default=[],
     help="Addons to exclude always.")
 
 # Generate the matching addons set

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -115,7 +115,7 @@ class ScaffoldingCase(unittest.TestCase):
                 ("test", "!", "-e", "auto/addons/private_addon"),
                 ("bash", "-c", 'test -z "$(addons list -p)"'),
                 ("bash", "-c",
-                 '[ "$(addons list -s. -pwfake1,fake2)" == fake1.fake2 ]'),
+                 '[ "$(addons list -s. -pwfake1 -wfake2)" == fake1.fake2 ]'),
                 ("bash", "-c", "! addons list -wrepeat -Wrepeat"),
                 ("bash", "-c", 'addons list -c | grep ,crm,'),
             )

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -156,7 +156,7 @@ class ScaffoldingCase(unittest.TestCase):
                 dict(sub_env, DBNAME="limited_core"),
                 ("test", "-e", "auto/addons/dummy_addon"),
                 ("bash", "-c",
-                 '[ "$(addons list -s. -pwfake1,fake2)" == fake1.fake2 ]'),
+                 '[ "$(addons list -s. -pwfake1 -wfake2)" == fake1.fake2 ]'),
                 ("bash", "-c",
                  'test "$(addons list -e)" == dummy_addon,product'),
                 ("bash", "-c", 'test "$(addons list -c)" == crm,sale'),


### PR DESCRIPTION
Comma-separated lists grow too much quickly

This breaks API from #123, but since it was merged minutes ago, I think nobody will care.