### PR TITLE
Proxy for Odoo in devel

### DIFF
--- a/devel.yaml
+++ b/devel.yaml
@@ -2,7 +2,7 @@ version: "2.1"
 
 services:
     odoo_proxy:
-        image: alpine
+        image: tecnativa/whitelist
         depends_on:
             - odoo
         networks: &public
@@ -10,7 +10,9 @@ services:
             public:
         ports:
             - "127.0.0.1:${ODOO_MAJOR}069:8069"
-        command: [nc, -lkp, "8069", -e, nc, odoo, "8069"]
+        environment:
+            PORT: 8069
+            TARGET: odoo
 
     odoo:
         extends:

--- a/devel.yaml
+++ b/devel.yaml
@@ -1,6 +1,17 @@
 version: "2.1"
 
 services:
+    odoo_proxy:
+        image: alpine
+        depends_on:
+            - odoo
+        networks: &public
+            default:
+            public:
+        ports:
+            - "127.0.0.1:${ODOO_MAJOR}069:8069"
+        command: [nc, -lkp, "8069", -e, nc, odoo, "8069"]
+
     odoo:
         extends:
             file: common.yaml
@@ -20,10 +31,6 @@ services:
             SMTP_PORT: "1025"
             # You want demo data for development
             WITHOUT_DEMO: "false"
-        ports:
-            - "127.0.0.1:${ODOO_MAJOR}069:8069"
-            - "127.0.0.1:${ODOO_MAJOR}072:8072"
-            - "127.0.0.1:6899:6899"
         volumes:
             - ./odoo/custom:/opt/odoo/custom:ro,z
             - ./odoo/auto/addons:/opt/odoo/auto/addons:rw,z
@@ -46,17 +53,20 @@ services:
         extends:
             file: common.yaml
             service: smtpfake
+        networks: *public
         ports:
             - "127.0.0.1:8025:8025"
 
     wdb:
         image: yajo/wdb-server
+        networks: *public
         ports:
             - "127.0.0.1:1984:1984"
 
 networks:
     default:
         internal: true
+    public:
 
 volumes:
     filestore:


### PR DESCRIPTION
To fix #120:

- Add a new "public" network, which has no restriction
- Bind wdb and smtp containers to that network, since they have no data leakage possibility
- Add a new odoo_proxy service: just a blind netcat that allows external connections to odoo
- Odoo and db are still isolated and cannot access the public network, so the isolation features remain untouched.