### PR TITLE
[FIX] Freeze psycopg2 library

### DIFF
--- a/bin/install.sh
+++ b/bin/install.sh
@@ -39,18 +39,12 @@ else
     pip_deps="psutil==4.3.1 pydot==1.2.3"
 fi
 
-# psycopg2 will be installed later
-sed -ir 's/psycopg2/#\0/' $reqs
-
 optimize="$PYTHONOPTIMIZE"
 if [ $PYTHONOPTIMIZE -gt 1 ]; then
     export PYTHONOPTIMIZE=1
 fi
 pip install --no-cache-dir $pip_deps
 export PYTHONOPTIMIZE="$optimize"
-
-# Security upgrades
-pip install --no-cache-dir "psycopg2>=2.7" # ODOO-SA-2017-06-15-1
 
 # Build and install Odoo dependencies with pip
 pip install --no-cache-dir --requirement $reqs


### PR DESCRIPTION
The current `psycopg2` version (`2.7.4` as of today) shows a **UserWarning** about future packaging changes. Force the version found in the `requirements.txt` from **OCA/OCB**.

This also ensures that the package `psycopg2` won't be reinstalled when enabling `AUTO_REQUIREMENTS` if the `requirements.txt` is synced with the **OCB**'s one.

The log in question is:
> /usr/local/lib/python2.7/dist-packages/psycopg2/__init__.py:144: UserWarning: The psycopg2 wheel package will be renamed from release 2.8; in order to keep installing from binary please use "pip install psycopg2-binary" instead. For details see: <http://initd.org/psycopg/docs/install.html#binary-install-from-pypi>.
  """)