### PR TITLE
Support $INITIAL_LANG

### DIFF
--- a/11.0.Dockerfile
+++ b/11.0.Dockerfile
@@ -66,6 +66,7 @@ ENV DEPTH_DEFAULT=1 \
     DEPTH_MERGE=100 \
     EMAIL=https://hub.docker.com/r/tecnativa/odoo \
     GIT_AUTHOR_NAME=docker-odoo \
+    INITIAL_LANG="" \
     LC_ALL=C.UTF-8 \
     NODE_PATH=/usr/local/lib/node_modules:/usr/lib/node_modules \
     OPENERP_SERVER=/opt/odoo/auto/odoo.conf \

--- a/8.0.Dockerfile
+++ b/8.0.Dockerfile
@@ -66,6 +66,7 @@ ENV DEPTH_DEFAULT=1 \
     DEPTH_MERGE=100 \
     EMAIL=https://hub.docker.com/r/tecnativa/odoo \
     GIT_AUTHOR_NAME=docker-odoo \
+    INITIAL_LANG="" \
     LC_ALL=C.UTF-8 \
     OPENERP_SERVER=/opt/odoo/auto/odoo.conf \
     PATH="/home/odoo/.local/bin:$PATH" \

--- a/README.md
+++ b/README.md
@@ -861,6 +861,16 @@ To **add** the `www.` prefix, it is almost the same; use your imagination
 
 In `.env`, set `DOMAIN_PROD` to `host1.com,host2.com,www.host1.com`, etc.
 
+### How to choose initial DB creation language?
+
+This image includes a hack that will set the initial language to load when
+Odoo creates its database for the first time. These conditions must match:
+
+- `$PGDATABASE` is set.
+- That database does not yet exist.
+- `$INITIAL_LANG` is set to any Odoo lang code. I.e. `es_ES`.
+- Odoo is booted.
+
 ### I use [Fish][], how to export needed variables?
 
 Do:

--- a/bin/direxec
+++ b/bin/direxec
@@ -4,6 +4,8 @@ import os
 import subprocess
 import sys
 
+from psycopg2 import connect, OperationalError
+
 from odoobaselib import logging
 
 # Call this file linked from another file called `build` or `entrypoint`
@@ -32,5 +34,13 @@ extra_command = sys.argv[1:]
 if extra_command:
     if extra_command[0] == 'shell' or extra_command[0].startswith("-"):
         extra_command.insert(0, "odoo")
+    # Set the DB creation language, if needed
+    if extra_command[0] == "odoo" and os.environ.get("INITIAL_LANG"):
+        try:
+            connection = connect(dbname=os.environ.get("PGDATABASE"))
+            connection.close()
+        except OperationalError:
+            # No DB exists, set initial language
+            extra_command += ["--load-language", os.environ["INITIAL_LANG"]]
     logging.info("Executing %s", " ".join(extra_command))
     os.execvp(extra_command[0], extra_command)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -7,12 +7,11 @@ import logging
 import tempfile
 import unittest
 
-from glob import iglob
-from itertools import product, starmap
+from itertools import product
 from os import environ, getlogin
-from os.path import basename, dirname, join
+from os.path import dirname, join
 from pwd import getpwnam
-from subprocess import PIPE, Popen
+from subprocess import Popen
 
 logging.basicConfig(level=logging.DEBUG)
 
@@ -171,8 +170,12 @@ class ScaffoldingCase(unittest.TestCase):
             ("--stop-after-init",),
             # SMTP settings work
             ("./custom/scripts/test_smtp_settings.py",),
+            # DB was created with the correct language
+            ("bash", "-c",
+             """test "$(psql -Atqc "SELECT code FROM res_lang
+                                    WHERE active = TRUE")" == es_ES"""),
         )
-        # Odoo 8.0 has no shell
+        # Odoo 8.0 has no shell, and doesn't autocreate DB
         for sub_env in matrix(odoo_skip={"8.0"}):
             self.compose_test(folder, sub_env, *commands)
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -170,13 +170,18 @@ class ScaffoldingCase(unittest.TestCase):
             ("--stop-after-init",),
             # SMTP settings work
             ("./custom/scripts/test_smtp_settings.py",),
+        )
+        # Odoo 8.0 has no shell, and --load-language doesn't work fine in 9.0
+        for sub_env in matrix(odoo={"9.0"}):
+            self.compose_test(folder, sub_env, *commands)
+        # Extra tests for versions >= 10.0, that support --load-language fine
+        commands += (
             # DB was created with the correct language
             ("bash", "-c",
              """test "$(psql -Atqc "SELECT code FROM res_lang
                                     WHERE active = TRUE")" == es_ES"""),
         )
-        # Odoo 8.0 has no shell, and doesn't autocreate DB
-        for sub_env in matrix(odoo_skip={"8.0"}):
+        for sub_env in matrix(odoo_skip={"8.0", "9.0"}):
             self.compose_test(folder, sub_env, *commands)
 
     def test_smallest(self):

--- a/tests/scaffoldings/settings/docker-compose.yaml
+++ b/tests/scaffoldings/settings/docker-compose.yaml
@@ -11,6 +11,7 @@ services:
     tty: true
     environment:
       EMAIL_FROM: test@example.com
+      INITIAL_LANG: es_ES
       PGUSER: another_odoo
       PGPASSWORD: anotherodoopassword
       PGHOST: postgresql


### PR DESCRIPTION
Lets automated deployments of new databases with only one language that is not en_US.