### PR TITLE
Upgrade to Node 6.x (LTS) and Less 2.x in all versions

### DIFF
--- a/11.0.Dockerfile
+++ b/11.0.Dockerfile
@@ -96,7 +96,7 @@ RUN apt-get -qq update \
         bzip2 ca-certificates curl gettext-base git gnupg2 nano \
         openssh-client postgresql-client telnet xz-utils \
     && curl https://bootstrap.pypa.io/get-pip.py | python3 /dev/stdin \
-    && curl -sL https://deb.nodesource.com/setup_8.x | bash - \
+    && curl -sL https://deb.nodesource.com/setup_6.x | bash - \
     && apt-get install -yqq nodejs \
     && apt-get -yqq purge python2.7 \
     && apt-get -yqq autoremove \
@@ -104,7 +104,7 @@ RUN apt-get -qq update \
 
 # Special case to get latest Less and PhantomJS
 RUN ln -s /usr/bin/nodejs /usr/local/bin/node \
-    && npm install -g less phantomjs-prebuilt \
+    && npm install -g less@2 less-plugin-clean-css@1 phantomjs-prebuilt@2 \
     && rm -Rf ~/.npm /tmp/*
 
 # Special case to get bootstrap-sass, required by Odoo for Sass assets

--- a/11.0.Dockerfile
+++ b/11.0.Dockerfile
@@ -96,7 +96,7 @@ RUN apt-get -qq update \
         bzip2 ca-certificates curl gettext-base git gnupg2 nano \
         openssh-client postgresql-client telnet xz-utils \
     && curl https://bootstrap.pypa.io/get-pip.py | python3 /dev/stdin \
-    && curl -sL https://deb.nodesource.com/setup_6.x | bash - \
+    && curl -sL https://deb.nodesource.com/setup_8.x | bash - \
     && apt-get install -yqq nodejs \
     && apt-get -yqq purge python2.7 \
     && apt-get -yqq autoremove \

--- a/8.0.Dockerfile
+++ b/8.0.Dockerfile
@@ -95,7 +95,7 @@ RUN apt-get update \
         bzip2 ca-certificates curl gettext-base git nano \
         openssh-client telnet xz-utils \
     && curl https://bootstrap.pypa.io/get-pip.py | python /dev/stdin \
-    && curl -sL https://deb.nodesource.com/setup_8.x | bash - \
+    && curl -sL https://deb.nodesource.com/setup_6.x | bash - \
     && apt-get install -yqq nodejs \
     && rm -Rf /var/lib/apt/lists/*
 
@@ -109,18 +109,14 @@ RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ jessie-pgdg main' >> /etc
     && apt-get install -y --no-install-recommends postgresql-client \
     && rm -Rf /var/lib/apt/lists/* /tmp/*
 
-# Special case to get latest Less
-RUN npm install -g less \
+# Special case to get latest Less and PhantomJS
+RUN ln -s /usr/bin/nodejs /usr/local/bin/node \
+    && npm install -g less@2 less-plugin-clean-css@1 phantomjs-prebuilt@2 \
     && rm -Rf ~/.npm /tmp/*
 
 # Special case to get bootstrap-sass, required by Odoo for Sass assets
 RUN gem install --no-rdoc --no-ri --no-update-sources bootstrap-sass --version '<4' \
     && rm -Rf ~/.gem /var/lib/gems/*/cache/
-
-# Special case for PhantomJS
-RUN ln -s /usr/bin/nodejs /usr/local/bin/node \
-    && npm install -g phantomjs-prebuilt@2.1.15 \
-    && rm -Rf ~/.npm /tmp/*
 
 # Special case for wkhtmltox
 RUN curl -SLo wkhtmltox.tar.xz https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/${WKHTMLTOPDF_VERSION}/wkhtmltox-${WKHTMLTOPDF_VERSION}_linux-generic-amd64.tar.xz \

--- a/8.0.Dockerfile
+++ b/8.0.Dockerfile
@@ -69,6 +69,7 @@ ENV DB_FILTER=.* \
     GIT_AUTHOR_NAME=docker-odoo \
     INITIAL_LANG="" \
     LC_ALL=C.UTF-8 \
+    NODE_PATH=/usr/local/lib/node_modules:/usr/lib/node_modules \
     OPENERP_SERVER=/opt/odoo/auto/odoo.conf \
     PATH="/home/odoo/.local/bin:$PATH" \
     PIP_NO_CACHE_DIR=0 \
@@ -98,9 +99,6 @@ RUN apt-get update \
     && curl -sL https://deb.nodesource.com/setup_6.x | bash - \
     && apt-get install -yqq nodejs \
     && rm -Rf /var/lib/apt/lists/*
-
-# Make node find --global addons
-ENV NODE_PATH=/usr/local/lib/node_modules
 
 # Special case to get latest PostgreSQL client
 RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ jessie-pgdg main' >> /etc/apt/sources.list.d/postgresql.list \

--- a/8.0.Dockerfile
+++ b/8.0.Dockerfile
@@ -92,9 +92,11 @@ RUN apt-get update \
         libfreetype6 liblcms2-2 libopenjpeg5 libtiff5 tk tcl libpq5 \
         libldap-2.4-2 libsasl2-2 libx11-6 libxext6 libxrender1 \
         locales-all zlibc \
-        bzip2 ca-certificates curl gettext-base git nano npm \
+        bzip2 ca-certificates curl gettext-base git nano \
         openssh-client telnet xz-utils \
     && curl https://bootstrap.pypa.io/get-pip.py | python /dev/stdin \
+    && curl -sL https://deb.nodesource.com/setup_8.x | bash - \
+    && apt-get install -yqq nodejs \
     && rm -Rf /var/lib/apt/lists/*
 
 # Make node find --global addons


### PR DESCRIPTION
This should remove some warnings from builds like these:

```
WARN engine less@3.0.2: wanted: {"node":">=4"} (current: {"node":"0.10.29","npm":"1.4.21"}) 
```

Also I hope it adds a workaround for one problem found, related to https://github.com/odoo/odoo/pull/24246, which rendered a useless website with:

    The "--no-js" argument is deprecated, as inline JavaScript is disabled by default. Use "--js" to enable inline JavaScript (not recommended).
    
    /usr/local/lib/node_modules/less/node_modules/request/node_modules/hawk/node_modules/boom/lib/index.js:5
    const Hoek = require('hoek');
    ^^^^^
    FileError: optional dependency 'request' required to import over http(s)
    in - on line 342, column 1:
    341 // General styles
    342 @import url(//fonts.googleapis.com/css?family=Open+Sans:400,400italic);
    343 