### PR TITLE
[DCK] Add gravatar proxy

### DIFF
--- a/devel.yaml
+++ b/devel.yaml
@@ -37,7 +37,11 @@ services:
             - ./odoo/custom:/opt/odoo/custom:ro,z
             - ./odoo/auto/addons:/opt/odoo/auto/addons:rw,z
         depends_on:
+            - cdnjs_cloudflare_proxy
             - db
+            - fonts_googleapis_proxy
+            - fonts_gstatic_proxy
+            - gravatar_proxy
             - smtp
             - wdb
         command:
@@ -64,6 +68,55 @@ services:
         networks: *public
         ports:
             - "127.0.0.1:1984:1984"
+
+    # Whitelist outgoing traffic for tests, reports, etc.
+    cdnjs_cloudflare_proxy:
+        image: tecnativa/whitelist
+        restart: unless-stopped
+        networks:
+            default:
+                aliases:
+                    - cdnjs.cloudflare.com
+            public:
+        environment:
+            TARGET: cdnjs.cloudflare.com
+            PRE_RESOLVE: 1
+
+    fonts_googleapis_proxy:
+        image: tecnativa/whitelist
+        restart: unless-stopped
+        networks:
+            default:
+                aliases:
+                    - fonts.googleapis.com
+            public:
+        environment:
+            TARGET: fonts.googleapis.com
+            PRE_RESOLVE: 1
+
+    fonts_gstatic_proxy:
+        image: tecnativa/whitelist
+        restart: unless-stopped
+        networks:
+            default:
+                aliases:
+                    - fonts.gstatic.com
+            public:
+        environment:
+            TARGET: fonts.gstatic.com
+            PRE_RESOLVE: 1
+
+    gravatar_proxy:
+        image: tecnativa/whitelist
+        restart: unless-stopped
+        networks:
+            default:
+                aliases:
+                    - www.gravatar.com
+            public:
+        environment:
+            TARGET: www.gravatar.com
+            PRE_RESOLVE: 1
 
 networks:
     default:

--- a/test.yaml
+++ b/test.yaml
@@ -15,6 +15,7 @@ services:
             - db
             - fonts_googleapis_proxy
             - fonts_gstatic_proxy
+            - gravatar_proxy
             - smtp
         networks:
             default:
@@ -94,6 +95,18 @@ services:
             public:
         environment:
             TARGET: fonts.gstatic.com
+            PRE_RESOLVE: 1
+
+    gravatar_proxy:
+        image: tecnativa/whitelist
+        restart: unless-stopped
+        networks:
+            default:
+                aliases:
+                    - www.gravatar.com
+            public:
+        environment:
+            TARGET: www.gravatar.com
             PRE_RESOLVE: 1
 
 networks:


### PR DESCRIPTION
The file `res_partner_demo.yml` from Odoo base addon was extremely slow to load due to trying to connect to Gravatar. This should speed up all CI builds significatively.

Also include all service proxies from test.yaml into devel.yaml, to speed up reporting at devel time.

@lreficent, this should be fixing the problems you commented to me privately, right?