### PR TITLE
[FIX] setting environment variable UNACCENT to false

### DIFF
--- a/entrypoint.d/35-unaccent-config
+++ b/entrypoint.d/35-unaccent-config
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e
+# correct unaccent in config to the given environment value
+sed -i 's/\(unaccent = \)\(.*\)$/\1 '$UNACCENT'/' /opt/odoo/auto/odoo.conf


### PR DESCRIPTION
when setting environment variable UNACCENT to false this should be also reflected in odoo.conf

Previously we would get a warning in the logfile of odoo if we started the docker container with environment UNACCENT: "false":
init The option --unaccent was given but no unaccent() function was found in database.

This happened because 30-unaccent-install did skip installing to db but /opt/odoo/auto/odoo.conf was already generated in build with arg UNACCENT=true

Info @wt-io-it