### PR TITLE
Main scaffolding is now 11.0

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -15,7 +15,7 @@ from subprocess import Popen
 
 logging.basicConfig(level=logging.DEBUG)
 
-MAIN_SCAFFOLDING_VERSION = "10.0"
+MAIN_SCAFFOLDING_VERSION = "11.0"
 DIR = dirname(__file__)
 ODOO_PREFIX = ("odoo", "--stop-after-init", "--workers=0")
 ODOO_VERSIONS = frozenset(environ.get(


### PR DESCRIPTION
See https://github.com/Tecnativa/docker-odoo-base/issues/67#issuecomment-383051415 for details.

Tests using v10 main scaffolding were testing old image alnog with new one.