### PR TITLE
Include pg_activity in base image

### DIFF
--- a/11.0.Dockerfile
+++ b/11.0.Dockerfile
@@ -121,7 +121,7 @@ RUN curl -SLo wkhtmltox.tar.xz https://github.com/wkhtmltopdf/wkhtmltopdf/releas
 # Other facilities
 WORKDIR /opt/odoo
 RUN pip install \
-    astor git-aggregator openupgradelib ptvsd==3.0.0 pudb wdb
+    astor git-aggregator openupgradelib 'pg_activity<1.5' ptvsd==3.0.0 pudb wdb
 COPY bin/* /usr/local/bin/
 COPY lib/odoobaselib /usr/local/lib/python3.5/dist-packages/odoobaselib
 COPY build.d common/build.d

--- a/11.0.Dockerfile
+++ b/11.0.Dockerfile
@@ -121,7 +121,7 @@ RUN curl -SLo wkhtmltox.tar.xz https://github.com/wkhtmltopdf/wkhtmltopdf/releas
 # Other facilities
 WORKDIR /opt/odoo
 RUN pip install \
-    astor git-aggregator openupgradelib 'pg_activity<1.5' ptvsd==3.0.0 pudb wdb
+    astor git-aggregator openupgradelib ptvsd==3.0.0 pudb wdb
 COPY bin/* /usr/local/bin/
 COPY lib/odoobaselib /usr/local/lib/python3.5/dist-packages/odoobaselib
 COPY build.d common/build.d
@@ -154,6 +154,7 @@ RUN apt-get update \
         python3-dev \
         zlib1g-dev \
     && pip install -r https://raw.githubusercontent.com/$ODOO_SOURCE/$ODOO_VERSION/requirements.txt \
+    && pip install 'pg_activity<1.5' \
     && (python3 -m compileall -q /usr/local/lib/python3.5/ || true) \
     && apt-get purge -yqq build-essential '*-dev' \
     && apt-mark -qq manual '*' \

--- a/8.0.Dockerfile
+++ b/8.0.Dockerfile
@@ -126,7 +126,7 @@ RUN curl -SLo wkhtmltox.tar.xz https://github.com/wkhtmltopdf/wkhtmltopdf/releas
 # Other facilities
 WORKDIR /opt/odoo
 RUN pip install \
-    astor git-aggregator openupgradelib ptvsd==3.0.0 pudb wdb
+    astor git-aggregator openupgradelib 'pg_activity<1.5' ptvsd==3.0.0 pudb wdb
 COPY bin/* /usr/local/bin/
 COPY lib/odoobaselib /usr/local/lib/python2.7/dist-packages/odoobaselib
 COPY build.d common/build.d

--- a/8.0.Dockerfile
+++ b/8.0.Dockerfile
@@ -126,7 +126,7 @@ RUN curl -SLo wkhtmltox.tar.xz https://github.com/wkhtmltopdf/wkhtmltopdf/releas
 # Other facilities
 WORKDIR /opt/odoo
 RUN pip install \
-    astor git-aggregator openupgradelib 'pg_activity<1.5' ptvsd==3.0.0 pudb wdb
+    astor git-aggregator openupgradelib ptvsd==3.0.0 pudb wdb
 COPY bin/* /usr/local/bin/
 COPY lib/odoobaselib /usr/local/lib/python2.7/dist-packages/odoobaselib
 COPY build.d common/build.d
@@ -146,6 +146,7 @@ ARG ODOO_SOURCE=OCA/OCB
 ARG ODOO_VERSION=10.0
 ENV ODOO_VERSION="$ODOO_VERSION"
 RUN install.sh
+RUN pip install 'pg_activity<1.5'
 
 # HACK Special case for Werkzeug
 USER odoo

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -192,6 +192,7 @@ class ScaffoldingCase(unittest.TestCase):
             ("test", "-d", "/opt/odoo/custom/src/private"),
             ("test", "-d", "/opt/odoo/custom/ssh"),
             ("test", "-x", "/usr/local/bin/unittest"),
+            ("pg_activity", "--version"),
             # Must be able to install base addon
             ODOO_PREFIX + ("--init", "base"),
             # Auto updater must work


### PR DESCRIPTION
We find ourselves to be installing this quite often to track performance and concurrency issues, so it's better to bundle it.