### PR TITLE
Upgrade to wkhtmltox 0.12.5

### DIFF
--- a/11.0.Dockerfile
+++ b/11.0.Dockerfile
@@ -100,8 +100,7 @@ RUN apt-get -qq update \
     && apt-get install -yqq nodejs \
     && curl -SLo wkhtmltox.deb https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/${WKHTMLTOPDF_VERSION}/wkhtmltox_${WKHTMLTOPDF_VERSION}-1.stretch_amd64.deb \
     && echo "${WKHTMLTOPDF_CHECKSUM}  wkhtmltox.deb" | sha256sum -c - \
-    && dpkg --install wkhtmltox.deb \
-    && apt-get install --fix-broken \
+    && apt-get install ./wkhtmltox.deb \
     && rm wkhtmltox.deb \
     && wkhtmltopdf --version \
     && apt-get -yqq purge python2.7 \

--- a/11.0.Dockerfile
+++ b/11.0.Dockerfile
@@ -60,8 +60,8 @@ ONBUILD RUN mkdir -p /opt/odoo/custom/ssh \
 ONBUILD RUN /opt/odoo/common/build && sync
 ONBUILD USER odoo
 
-ARG WKHTMLTOPDF_VERSION=0.12.4
-ARG WKHTMLTOPDF_CHECKSUM='049b2cdec9a8254f0ef8ac273afaf54f7e25459a273e27189591edc7d7cf29db'
+ARG WKHTMLTOPDF_VERSION=0.12.5
+ARG WKHTMLTOPDF_CHECKSUM='1140b0ab02aa6e17346af2f14ed0de807376de475ba90e1db3975f112fbd20bb'
 ENV DB_FILTER=.* \
     DEPTH_DEFAULT=1 \
     DEPTH_MERGE=100 \
@@ -98,6 +98,12 @@ RUN apt-get -qq update \
     && curl https://bootstrap.pypa.io/get-pip.py | python3 /dev/stdin \
     && curl -sL https://deb.nodesource.com/setup_6.x | bash - \
     && apt-get install -yqq nodejs \
+    && curl -SLo wkhtmltox.deb https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/${WKHTMLTOPDF_VERSION}/wkhtmltox_${WKHTMLTOPDF_VERSION}-1.stretch_amd64.deb \
+    && echo "${WKHTMLTOPDF_CHECKSUM}  wkhtmltox.deb" | sha256sum -c - \
+    && dpkg --install wkhtmltox.deb \
+    && apt-get install --fix-broken \
+    && rm wkhtmltox.deb \
+    && wkhtmltopdf --version \
     && apt-get -yqq purge python2.7 \
     && apt-get -yqq autoremove \
     && rm -Rf /var/lib/apt/lists/*
@@ -110,13 +116,6 @@ RUN ln -s /usr/bin/nodejs /usr/local/bin/node \
 # Special case to get bootstrap-sass, required by Odoo for Sass assets
 RUN gem install --no-rdoc --no-ri --no-update-sources bootstrap-sass --version '<4' \
     && rm -Rf ~/.gem /var/lib/gems/*/cache/
-
-# Special case for wkhtmltox
-RUN curl -SLo wkhtmltox.tar.xz https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/${WKHTMLTOPDF_VERSION}/wkhtmltox-${WKHTMLTOPDF_VERSION}_linux-generic-amd64.tar.xz \
-    && echo "${WKHTMLTOPDF_CHECKSUM}  wkhtmltox.tar.xz" | sha256sum -c - \
-    && tar --strip-components 1 -C /usr/local/ -xf wkhtmltox.tar.xz \
-    && rm wkhtmltox.tar.xz \
-    && wkhtmltopdf --version
 
 # Other facilities
 WORKDIR /opt/odoo

--- a/11.0.Dockerfile
+++ b/11.0.Dockerfile
@@ -100,7 +100,7 @@ RUN apt-get -qq update \
     && apt-get install -yqq nodejs \
     && curl -SLo wkhtmltox.deb https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/${WKHTMLTOPDF_VERSION}/wkhtmltox_${WKHTMLTOPDF_VERSION}-1.stretch_amd64.deb \
     && echo "${WKHTMLTOPDF_CHECKSUM}  wkhtmltox.deb" | sha256sum -c - \
-    && apt-get install ./wkhtmltox.deb \
+    && apt-get install -yqq --no-install-recommends ./wkhtmltox.deb \
     && rm wkhtmltox.deb \
     && wkhtmltopdf --version \
     && apt-get -yqq purge python2.7 \

--- a/8.0.Dockerfile
+++ b/8.0.Dockerfile
@@ -100,7 +100,7 @@ RUN apt-get update \
     && apt-get install -yqq nodejs \
     && curl -SLo wkhtmltox.deb https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/${WKHTMLTOPDF_VERSION}/wkhtmltox_${WKHTMLTOPDF_VERSION}-1.jessie_amd64.deb \
     && echo "${WKHTMLTOPDF_CHECKSUM}  wkhtmltox.deb" | sha256sum -c - \
-    && dpkg --install wkhtmltox.deb \
+    && (dpkg --install wkhtmltox.deb || true) \
     && apt-get install --fix-broken \
     && rm wkhtmltox.deb \
     && wkhtmltopdf --version \

--- a/8.0.Dockerfile
+++ b/8.0.Dockerfile
@@ -101,7 +101,7 @@ RUN apt-get update \
     && curl -SLo wkhtmltox.deb https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/${WKHTMLTOPDF_VERSION}/wkhtmltox_${WKHTMLTOPDF_VERSION}-1.jessie_amd64.deb \
     && echo "${WKHTMLTOPDF_CHECKSUM}  wkhtmltox.deb" | sha256sum -c - \
     && (dpkg --install wkhtmltox.deb || true) \
-    && apt-get install --fix-broken \
+    && apt-get install -yqq --no-install-recommends --fix-broken \
     && rm wkhtmltox.deb \
     && wkhtmltopdf --version \
     && rm -Rf /var/lib/apt/lists/*

--- a/8.0.Dockerfile
+++ b/8.0.Dockerfile
@@ -60,8 +60,8 @@ ONBUILD RUN mkdir -p /opt/odoo/custom/ssh \
 ONBUILD RUN /opt/odoo/common/build && sync
 ONBUILD USER odoo
 
-ARG WKHTMLTOPDF_VERSION=0.12.4
-ARG WKHTMLTOPDF_CHECKSUM='049b2cdec9a8254f0ef8ac273afaf54f7e25459a273e27189591edc7d7cf29db'
+ARG WKHTMLTOPDF_VERSION=0.12.5
+ARG WKHTMLTOPDF_CHECKSUM='2583399a865d7604726da166ee7cec656b87ae0a6016e6bce7571dcd3045f98b'
 ENV DB_FILTER=.* \
     DEPTH_DEFAULT=1 \
     DEPTH_MERGE=100 \
@@ -98,6 +98,12 @@ RUN apt-get update \
     && curl https://bootstrap.pypa.io/get-pip.py | python /dev/stdin \
     && curl -sL https://deb.nodesource.com/setup_6.x | bash - \
     && apt-get install -yqq nodejs \
+    && curl -SLo wkhtmltox.deb https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/${WKHTMLTOPDF_VERSION}/wkhtmltox_${WKHTMLTOPDF_VERSION}-1.jessie_amd64.deb \
+    && echo "${WKHTMLTOPDF_CHECKSUM}  wkhtmltox.deb" | sha256sum -c - \
+    && dpkg --install wkhtmltox.deb \
+    && apt-get install --fix-broken \
+    && rm wkhtmltox.deb \
+    && wkhtmltopdf --version \
     && rm -Rf /var/lib/apt/lists/*
 
 # Special case to get latest PostgreSQL client
@@ -115,13 +121,6 @@ RUN ln -s /usr/bin/nodejs /usr/local/bin/node \
 # Special case to get bootstrap-sass, required by Odoo for Sass assets
 RUN gem install --no-rdoc --no-ri --no-update-sources bootstrap-sass --version '<4' \
     && rm -Rf ~/.gem /var/lib/gems/*/cache/
-
-# Special case for wkhtmltox
-RUN curl -SLo wkhtmltox.tar.xz https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/${WKHTMLTOPDF_VERSION}/wkhtmltox-${WKHTMLTOPDF_VERSION}_linux-generic-amd64.tar.xz \
-    && echo "${WKHTMLTOPDF_CHECKSUM}  wkhtmltox.tar.xz" | sha256sum -c - \
-    && tar --strip-components 1 -C /usr/local/ -xf wkhtmltox.tar.xz \
-    && rm wkhtmltox.tar.xz \
-    && wkhtmltopdf --version
 
 # Other facilities
 WORKDIR /opt/odoo


### PR DESCRIPTION
This release fixes the infamous bug https://github.com/wkhtmltopdf/wkhtmltopdf/issues/2711, and according to https://github.com/odoo/odoo/issues/21255#issuecomment-395358801 it should be mostly safe to upgrade from current 0.12.4 version.