### PR TITLE
Use latest Postgres in v11 image

### DIFF
--- a/11.0.Dockerfile
+++ b/11.0.Dockerfile
@@ -95,7 +95,7 @@ RUN apt-get -qq update \
         locales-all zlibc \
         bzip2 ca-certificates curl gettext-base git gnupg2 nano vim \
         openssh-client telnet xz-utils \
-    && echo 'deb http://apt.postgresql.org/pub/repos/apt/ jessie-pgdg main' >> /etc/apt/sources.list.d/postgresql.list \
+    && echo 'deb http://apt.postgresql.org/pub/repos/apt/ stretch-pgdg main' >> /etc/apt/sources.list.d/postgresql.list \
     && curl -SL https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
     && curl https://bootstrap.pypa.io/get-pip.py | python3 /dev/stdin \
     && curl -sL https://deb.nodesource.com/setup_6.x | bash - \

--- a/11.0.Dockerfile
+++ b/11.0.Dockerfile
@@ -94,10 +94,13 @@ RUN apt-get -qq update \
         libldap-2.4-2 libsasl2-2 libx11-6 libxext6 libxrender1 \
         locales-all zlibc \
         bzip2 ca-certificates curl gettext-base git gnupg2 nano vim \
-        openssh-client postgresql-client telnet xz-utils \
+        openssh-client telnet xz-utils \
+    && echo 'deb http://apt.postgresql.org/pub/repos/apt/ jessie-pgdg main' >> /etc/apt/sources.list.d/postgresql.list \
+    && curl -SL https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
     && curl https://bootstrap.pypa.io/get-pip.py | python3 /dev/stdin \
     && curl -sL https://deb.nodesource.com/setup_6.x | bash - \
-    && apt-get install -yqq nodejs \
+    && apt-get update \
+    && apt-get install -yqq --no-install-recommends nodejs postgresql-client \
     && curl -SLo wkhtmltox.deb https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/${WKHTMLTOPDF_VERSION}/wkhtmltox_${WKHTMLTOPDF_VERSION}-1.stretch_amd64.deb \
     && echo "${WKHTMLTOPDF_CHECKSUM}  wkhtmltox.deb" | sha256sum -c - \
     && apt-get install -yqq --no-install-recommends ./wkhtmltox.deb \


### PR DESCRIPTION
Versions 8-10 use postgres client libraries in version 10.x, but version 11 uses 9.x.

Since there's more backwards compatibility than forward, I'm upgrading libs in v11 image here too.