### PR TITLE
Provide better message on failed addons

### DIFF
--- a/bin/addons
+++ b/bin/addons
@@ -7,6 +7,7 @@ from argparse import ArgumentParser
 from subprocess import check_call
 from odoobaselib import (
     addons_config,
+    AddonsConfigError,
     CORE,
     logging,
     MANIFESTS,
@@ -56,34 +57,37 @@ addons = set(args.with_)
 without = set(args.without)
 if addons & without:
     sys.exit("Cannot include and exclude the same addon!")
-for addon, repo in addons_config(strict=args.explicit):
-    if addon in without:
-        continue
-    core_ok = args.core and repo == CORE
-    extra_ok = args.extra and repo not in {CORE, PRIVATE}
-    private_ok = args.private and repo == PRIVATE
-    if private_ok or core_ok or extra_ok:
-        addon_path = os.path.join(SRC_DIR, repo, addon)
-        if args.installable:
-            installable = False
-            manifests = list(MANIFESTS)
-            while True:
-                try:
-                    manifest = os.path.join(addon_path, manifests.pop())
-                    with open(manifest, "r") as code:
-                        manifest = ast.literal_eval(code.read())
-                except IndexError:
-                    break
-                except IOError:
+try:
+    for addon, repo in addons_config(strict=args.explicit):
+        if addon in without:
+            continue
+        core_ok = args.core and repo == CORE
+        extra_ok = args.extra and repo not in {CORE, PRIVATE}
+        private_ok = args.private and repo == PRIVATE
+        if private_ok or core_ok or extra_ok:
+            addon_path = os.path.join(SRC_DIR, repo, addon)
+            if args.installable:
+                installable = False
+                manifests = list(MANIFESTS)
+                while True:
+                    try:
+                        manifest = os.path.join(addon_path, manifests.pop())
+                        with open(manifest, "r") as code:
+                            manifest = ast.literal_eval(code.read())
+                    except IndexError:
+                        break
+                    except IOError:
+                        continue
+                    else:
+                        installable = manifest.get("installable", True)
+                        break
+                if not installable:
                     continue
-                else:
-                    installable = manifest.get("installable", True)
-                    break
-            if not installable:
-                continue
-        if args.fullpath and args.action == "list":
-            addon = addon_path
-        addons.add(addon)
+            if args.fullpath and args.action == "list":
+                addon = addon_path
+            addons.add(addon)
+except AddonsConfigError as error:
+    sys.exit(error.message)
 
 # Do the required action
 if not addons:

--- a/lib/odoobaselib/__init__.py
+++ b/lib/odoobaselib/__init__.py
@@ -45,6 +45,12 @@ else:
 logging.root.setLevel(_log_level)
 
 
+class AddonsConfigError(Exception):
+    def __init__(self, message, *args):
+        super(AddonsConfigError, self).__init__(message, *args)
+        self.message = message
+
+
 def addons_config(filtered=True, strict=False):
     """Yield addon name and path from ``ADDONS_YAML``.
 
@@ -113,7 +119,11 @@ def addons_config(filtered=True, strict=False):
         if missing_manifest:
             error += ["Addons without manifest:", pformat(missing_manifest)]
         if error:
-            raise Exception("\n".join(error), missing_glob, missing_manifest)
+            raise AddonsConfigError(
+                "\n".join(error),
+                missing_glob,
+                missing_manifest,
+            )
     # By default, all private and core addons are enabled
     for repo in special_missing:
         logging.debug("Auto-adding all addons from %s", repo)
@@ -134,6 +144,7 @@ def addons_config(filtered=True, strict=False):
         repos.discard(CORE)
         # Other addons fall in between
         if len(repos) != 1:
-            logging.error("Addon %s defined in several repos %s", addon, repos)
-            raise Exception
+            raise AddonsConfigError(
+                u"Addon {} defined in several repos {}".format(addon, repos),
+            )
         yield addon, repos.pop()


### PR DESCRIPTION
Now the error message will be pretty-printed when using `addons` script.