### PR TITLE
[DCK] Add image to odoo service

### DIFF
--- a/.env
+++ b/.env
@@ -3,6 +3,7 @@
 ODOO_MAJOR=11
 ODOO_MINOR=11.0
 INITIAL_LANG=
+ODOO_IMAGE=docker.io/myuser/myproject-odoo
 
 # XXX Critical for security!!!
 ODOO_ADMIN_PASSWORD=admin

--- a/common.yaml
+++ b/common.yaml
@@ -1,6 +1,7 @@
 version: "2.1"
 services:
     odoo:
+        image: $ODOO_IMAGE:$ODOO_MINOR
         build:
             context: ./odoo
             args:


### PR DESCRIPTION
This makes the `docker-compose push` command to work, and allows those of us using private registries to build only in CI and pull only in prod.